### PR TITLE
styling:  edit `is-primary` CSS class.

### DIFF
--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -137,7 +137,6 @@
 
       &.is-primary {
         color: $text;
-        text-decoration: none;
         font-weight: $weight-semibold;
       }
     }

--- a/ui/app/templates/components/task-row.hbs
+++ b/ui/app/templates/components/task-row.hbs
@@ -13,6 +13,7 @@
   <LinkTo
     @route="allocations.allocation.task"
     @models={{array this.task.allocation this.task}}
+    class="is-primary"
   >
     {{this.task.name}}
     {{#if this.task.isConnectProxy}}


### PR DESCRIPTION
After discussing styling for tables to be in compliance with WCAG, we're editing the `is-primary` CSS class, to no longer set `text-decoration` to `none`. This should be in compliance with WCAG, per my conversation with Josh.